### PR TITLE
Neos 9 compatibility (breaking!)

### DIFF
--- a/Resources/Private/Fusion/Components/Backend.fusion
+++ b/Resources/Private/Fusion/Components/Backend.fusion
@@ -5,5 +5,5 @@
 // To add your own type you have to define them in your Settings.yaml
 
 prototype(Carbon.Notification:Backend) < prototype(Carbon.Notification:Tag) {
-    @if.inBackend = ${node.context.inBackend}
+    @if.inBackend = ${renderingMode.isEdit}
 }

--- a/Resources/Private/Fusion/Components/Data.fusion
+++ b/Resources/Private/Fusion/Components/Data.fusion
@@ -5,7 +5,7 @@
 // To add your own type you have to define them in your Settings.yaml
 prototype(Carbon.Notification:Data) < prototype(Neos.Fusion:Value) {
     @if {
-        inBackend = ${node.context.inBackend}
+        inBackend = ${renderingMode.isEdit}
         hasContent = ${this.content}
     }
     content = ${value}

--- a/Resources/Private/Fusion/Components/Document.fusion
+++ b/Resources/Private/Fusion/Components/Document.fusion
@@ -3,7 +3,7 @@ prototype(Carbon.Notification:Document) < prototype(Neos.Fusion:Component) {
     title = null
 
     neosBackendHead = Neos.Fusion:Join {
-        @if.inBackend = ${documentNode.context.inBackend}
+        @if.inBackend = ${renderingMode.isEdit}
         javascriptBackendInformation = Neos.Neos.Ui:RenderConfiguration {
             path = 'documentNodeInformation'
             context {
@@ -16,8 +16,8 @@ prototype(Carbon.Notification:Document) < prototype(Neos.Fusion:Component) {
                 mode = 'cached'
                 entryIdentifier {
                     jsBackendInfo = 'javascriptBackendInformation'
-                    documentNode = ${documentNode}
-                    inBackend = ${documentNode.context.inBackend}
+                    documentNode = ${Neos.Caching.entryIdentifierForNode(documentNode)}
+                    inBackend = ${renderingMode.isEdit}
                 }
                 entryTags {
                     1 = ${Neos.Caching.nodeTag(documentNode)}
@@ -33,7 +33,7 @@ prototype(Carbon.Notification:Document) < prototype(Neos.Fusion:Component) {
     }
     neosUiNonRenderedNodeMetadata = Neos.Fusion:Value {
         @if {
-            inBackend = ${node.context.inBackend}
+            inBackend = ${renderingMode.isEdit}
             canRender = Neos.Fusion:CanRender {
                 type = 'Neos.Neos.Ui:RenderNonRenderedNodeMetadata'
             }
@@ -56,8 +56,8 @@ prototype(Carbon.Notification:Document) < prototype(Neos.Fusion:Component) {
                 </head>
                 <body style="font-family:'Noto Sans', ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol', 'Noto Color Emoji'">
                     <Carbon.Notification:Tag {...props} lang={null} />
-                    <div id='neos-backend-container' @if.inBackend={documentNode.context.inBackend}></div>
-                    <Neos.Fusion:Template templatePath='resource://Neos.Neos.Ui/Private/Templates/Backend/GuestNotificationScript.html' @if.inBackend={documentNode.context.inBackend} />
+                    <div id='neos-backend-container' @if.inBackend={renderingMode.isEdit}></div>
+                    <Neos.Fusion:Template templatePath='resource://Neos.Neos.Ui/Private/Templates/Backend/GuestNotificationScript.html' @if.inBackend={renderingMode.isEdit} />
                     {props.neosUiNonRenderedNodeMetadata}
                 </body>
             </html>

--- a/Resources/Private/Fusion/Components/Style.fusion
+++ b/Resources/Private/Fusion/Components/Style.fusion
@@ -2,7 +2,7 @@ prototype(Carbon.Notification:Style) < prototype(Neos.Fusion:Component) {
     config = ${Configuration.setting('Carbon.Notification')}
     types = ${Array.filter(this.config.types, entry => !!entry)}
 
-    @if.hasTypesAndInBackend = ${node.context.inBackend && Array.length(this.types)}
+    @if.hasTypesAndInBackend = ${renderingMode.isEdit && Array.length(this.types)}
 
     renderer = Neos.Fusion:Join {
         // These styles are for all types

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "carbon"
     ],
     "require": {
-        "neos/fusion": "^4.2 || ^5.0 || ^7.0 || ^8.0 || ^9.0 || dev-9.0"
+        "neos/fusion": "^9.0 || dev-master"
     },
     "authors": [
         {

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "carbon"
     ],
     "require": {
-        "neos/fusion": "^4.2 || ^5.0 || ^7.0 || ^8.0"
+        "neos/fusion": "^4.2 || ^5.0 || ^7.0 || ^8.0 || ^9.0 || dev-9.0"
     },
     "authors": [
         {


### PR DESCRIPTION
- require `"neos/fusion": "^9.0 || dev-master"` -> this is breaking so I removed the other versions, `dev-master` is included so the package can be installed in neos 9 projects before the official 9.0 release
- change `node.context.inBackend` to `renderingMode.isEdit`
- use `Neos.Caching.entryIdentifierForNode(document)` instead of just `document` for entryIdentifier
